### PR TITLE
Add travis-ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+python:
+    - "2.7"
+
+# Cache PlatformIO packages using Travis CI container-based infrastructure
+sudo: false
+cache:
+    directories:
+        - "~/.platformio"
+
+env:
+#    global:
+#        - PLATFORMIO_BUILD_FLAGS=-Werror
+    matrix:
+        - PLATFORMIO_CI_SRC=SodaqOneTracker_v2 PLATFORMIO_CI_EXTRA_ARGS="--board=sodaq_one"
+
+install:
+    - pip install -U platformio
+    - pio update
+
+script:
+    - platformio ci $PLATFORMIO_CI_EXTRA_ARGS


### PR DESCRIPTION
Adding a travis-ci configuration, please open an account on travis-ci.org so that there is a CI. After that a badge can be added to the readme.md