### PR TITLE
Fix cayenne encoding of battery voltage

### DIFF
--- a/SodaqOneTracker_v2/SodaqOneTracker_v2.ino
+++ b/SodaqOneTracker_v2/SodaqOneTracker_v2.ino
@@ -345,8 +345,8 @@ void updateSendBuffer()
         cayenneRecord.addGPS(1, latitude, longitude, altitude);
 
         // Add battery voltage on data channel 2
-        float voltage = (float)pendingReportDataRecord.getBatteryVoltage() * 10 + 3000;
-        cayenneRecord.addAnalogInput(2, voltage);
+        float millivolt = (float)pendingReportDataRecord.getBatteryVoltage() * 10 + 3000;
+        cayenneRecord.addAnalogInput(2, millivolt / 1000.0);
 
         // Add temperature on data channel 3
         float temp = (float)pendingReportDataRecord.getBoardTemperature();


### PR DESCRIPTION
Fix cayenne encoding of battery voltage by encoding it in volts (not millivolts).
Doing it this way avoids an integer overflow.

Example payload: "AYgH8CEAt03/+VwCAgGfA2cA8A=="
This decodes to:
* a GPS position of 52.0225, 4.6925, -17.00
* an analog input of 4.15
* a temperature of 24.0
