### PR TITLE
Fix cayenne encoding of battery voltage

### DIFF
--- a/SodaqOneTracker_v2/SodaqOneTracker_v2.ino
+++ b/SodaqOneTracker_v2/SodaqOneTracker_v2.ino
@@ -345,7 +345,7 @@ void updateSendBuffer()
         cayenneRecord.addGPS(1, latitude, longitude, altitude);
 
         // Add battery voltage on data channel 2
-        float voltage = (float)pendingReportDataRecord.getBatteryVoltage() * 10 + 3000;
+        float voltage = 3.0 + 0.01 * pendingReportDataRecord.getBatteryVoltage();
         cayenneRecord.addAnalogInput(2, voltage);
 
         // Add temperature on data channel 3


### PR DESCRIPTION
Fix cayenne encoding of battery voltage by encoding it in volts (not…… millivolts).
Doing it this way avoids an integer overflow. This is a simpler version than the earlier pull request.