### PR TITLE
Add platformio configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ Debug/
 
 # Other temp files
 *.bak
+.pio
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,18 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = SodaqOneTracker_v2
+
+[env:default]
+platform = atmelsam
+board = sodaq_one
+framework = arduino
+


### PR DESCRIPTION
This adds a platformio configuration, allowing the software to be built using the command-line tool platformio. Once installed you can compile and upload it using:
  pio run -t upload
The tool chain is automatically downloaded (and cached) by platformio.